### PR TITLE
Generify functions and userdata types

### DIFF
--- a/luna-compiler/src/main/java/org/classdump/luna/compiler/CompilerChunkLoader.java
+++ b/luna-compiler/src/main/java/org/classdump/luna/compiler/CompilerChunkLoader.java
@@ -17,8 +17,6 @@
 package org.classdump.luna.compiler;
 
 import org.classdump.luna.Variable;
-import org.classdump.luna.compiler.CompiledModule;
-import org.classdump.luna.compiler.CompilerSettings;
 import org.classdump.luna.load.ChunkClassLoader;
 import org.classdump.luna.load.ChunkLoader;
 import org.classdump.luna.load.LoaderException;
@@ -161,7 +159,7 @@ public class CompilerChunkLoader implements ChunkLoader {
 	}
 
 	@Override
-	public LuaFunction loadTextChunk(Variable env, String chunkName, String sourceText) throws LoaderException {
+	public LuaFunction<?, ?, ?, ?, ?> loadTextChunk(Variable env, String chunkName, String sourceText) throws LoaderException {
 		Objects.requireNonNull(env);
 		Objects.requireNonNull(chunkName);
 		Objects.requireNonNull(sourceText);

--- a/luna-examples/src/main/java/org/classdump/luna/examples/CallableUserdata.java
+++ b/luna-examples/src/main/java/org/classdump/luna/examples/CallableUserdata.java
@@ -41,7 +41,7 @@ import java.util.Arrays;
 
 public class CallableUserdata {
 
-	abstract static class AbstractCallableObject extends Userdata {
+	abstract static class AbstractCallableObject extends Userdata<Object> {
 
 		private static final Table mt = new ImmutableTable.Builder()
 				.add(Metatables.MT_CALL, new Call())

--- a/luna-examples/src/main/java/org/classdump/luna/examples/IteratorsUserdata.java
+++ b/luna-examples/src/main/java/org/classdump/luna/examples/IteratorsUserdata.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Kay Roepke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.classdump.luna.examples;
 
 import org.classdump.luna.Metatables;

--- a/luna-examples/src/main/java/org/classdump/luna/examples/TailCall.java
+++ b/luna-examples/src/main/java/org/classdump/luna/examples/TailCall.java
@@ -25,7 +25,7 @@ import org.classdump.luna.exec.DirectCallExecutor;
 import org.classdump.luna.impl.StateContexts;
 import org.classdump.luna.lib.StandardLibrary;
 import org.classdump.luna.load.LoaderException;
-import org.classdump.luna.runtime.AbstractFunction3;
+import org.classdump.luna.runtime.AbstractUntypedFunction3;
 import org.classdump.luna.runtime.Dispatch;
 import org.classdump.luna.runtime.ExecutionContext;
 import org.classdump.luna.runtime.ResolvedControlThrowable;
@@ -35,7 +35,7 @@ public class TailCall {
 
 	// equivalent to:
 	//   function (a, b, c) return a(b + c) end
-	static class ExampleFunction extends AbstractFunction3 {
+	static class ExampleFunction extends AbstractUntypedFunction3 {
 
 		@Override
 		public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3) throws ResolvedControlThrowable {

--- a/luna-luajava-compat/src/main/java/org/classdump/luna/lib/luajava/JavaWrapper.java
+++ b/luna-luajava-compat/src/main/java/org/classdump/luna/lib/luajava/JavaWrapper.java
@@ -23,12 +23,12 @@ import org.classdump.luna.Userdata;
 import org.classdump.luna.impl.NonsuspendableFunctionException;
 import org.classdump.luna.lib.NameMetamethodValueTypeNamer;
 import org.classdump.luna.runtime.AbstractFunction1;
-import org.classdump.luna.runtime.AbstractFunction2;
+import org.classdump.luna.runtime.AbstractUntypedFunction2;
 import org.classdump.luna.runtime.ExecutionContext;
 import org.classdump.luna.runtime.LuaFunction;
 import org.classdump.luna.runtime.ResolvedControlThrowable;
 
-abstract class JavaWrapper<T> extends Userdata {
+abstract class JavaWrapper<T> extends Userdata<Object> {
 
 	abstract String typeName();
 
@@ -54,19 +54,18 @@ abstract class JavaWrapper<T> extends Userdata {
 		throw new UnsupportedOperationException("cannot wrapper metatable");
 	}
 
-	static class ToString extends AbstractFunction1 {
+	static class ToString extends AbstractFunction1<JavaWrapper> {
 
 		public static final ToString INSTANCE = new ToString();
 
 		@Override
-		public void invoke(ExecutionContext context, Object arg1) throws ResolvedControlThrowable {
-			if (arg1 instanceof JavaWrapper) {
-				JavaWrapper wrapper = (JavaWrapper) arg1;
+		public void invoke(ExecutionContext context, JavaWrapper wrapper) throws ResolvedControlThrowable {
+			if (wrapper != null) {
 				context.getReturnBuffer().setTo(wrapper.typeName() + " (" + wrapper.get().toString() + ")");
 			}
 			else {
 				throw new IllegalArgumentException("invalid argument to toString: expecting Java wrapper, got "
-						+ NameMetamethodValueTypeNamer.typeNameOf(arg1, context));
+						+ NameMetamethodValueTypeNamer.typeNameOf(wrapper, context));
 			}
 		}
 
@@ -77,7 +76,7 @@ abstract class JavaWrapper<T> extends Userdata {
 
 	}
 
-	static abstract class AbstractGetMemberAccessor extends AbstractFunction2 {
+	static abstract class AbstractGetMemberAccessor extends AbstractUntypedFunction2 {
 
 		protected abstract LuaFunction methodAccessorForName(String methodName);
 

--- a/luna-runtime/src/main/java/org/classdump/luna/Userdata.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/Userdata.java
@@ -16,9 +16,6 @@
 
 package org.classdump.luna;
 
-import org.classdump.luna.LuaObject;
-import org.classdump.luna.Ordering;
-
 /**
  * Full userdata.
  *
@@ -31,14 +28,14 @@ import org.classdump.luna.Ordering;
  * userdata using {@link Object#equals(Object)}. <b>Exercise caution when overriding
  * {@code equals()}.</b></p>
  */
-public abstract class Userdata extends LuaObject {
+public abstract class Userdata<T> extends LuaObject {
 
 	/**
 	 * Returns the user value attached to this full userdata.
 	 *
 	 * @return  the user value attached to this full userdata
 	 */
-	public abstract Object getUserValue();
+	public abstract T getUserValue();
 
 	/**
 	 * Sets the user value attached to this full userdata to {@code value}, returning
@@ -47,6 +44,6 @@ public abstract class Userdata extends LuaObject {
 	 * @param value  new user value, may be {@code null}
 	 * @return  old user value
 	 */
-	public abstract Object setUserValue(Object value);
+	public abstract T setUserValue(T value);
 
 }

--- a/luna-runtime/src/main/java/org/classdump/luna/impl/DefaultUserdata.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/impl/DefaultUserdata.java
@@ -22,10 +22,10 @@ import org.classdump.luna.Userdata;
 /**
  * Default implementation of full userdata.
  */
-public abstract class DefaultUserdata extends Userdata {
+public abstract class DefaultUserdata<T> extends Userdata<T> {
 
 	private Table mt;
-	private Object userValue;
+	private T userValue;
 
 	/**
 	 * Constructs a new instance of this userdata with the specified initial {@code metatable}
@@ -34,7 +34,7 @@ public abstract class DefaultUserdata extends Userdata {
 	 * @param metatable  initial metatable, may be {@code null}
 	 * @param userValue  initial user value, may be {@code null}
 	 */
-	public DefaultUserdata(Table metatable, Object userValue) {
+	public DefaultUserdata(Table metatable, T userValue) {
 		this.mt = metatable;
 		this.userValue = userValue;
 	}
@@ -52,13 +52,13 @@ public abstract class DefaultUserdata extends Userdata {
 	}
 
 	@Override
-	public Object getUserValue() {
+	public T getUserValue() {
 		return userValue;
 	}
 
 	@Override
-	public Object setUserValue(Object value) {
-		Object oldValue = userValue;
+	public T setUserValue(T value) {
+		T oldValue = userValue;
 		this.userValue = value;
 		return oldValue;
 	}

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction0.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction0.java
@@ -16,12 +16,10 @@
 
 package org.classdump.luna.runtime;
 
-import org.classdump.luna.runtime.ResolvedControlThrowable;
-
 /**
  * Abstract function without arguments.
  */
-public abstract class AbstractFunction0 extends LuaFunction {
+public abstract class AbstractFunction0 extends LuaFunction<Object, Object, Object, Object, Object> {
 
 	@Override
 	public void invoke(ExecutionContext context, Object arg1) throws ResolvedControlThrowable {

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction1.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction1.java
@@ -16,45 +16,43 @@
 
 package org.classdump.luna.runtime;
 
-import org.classdump.luna.runtime.ExecutionContext;
-import org.classdump.luna.runtime.LuaFunction;
-
 /**
  * Abstract function of a single argument.
  */
-public abstract class AbstractFunction1 extends LuaFunction {
+public abstract class AbstractFunction1<T> extends LuaFunction<T, Object, Object, Object, Object> {
 
 	@Override
 	public void invoke(ExecutionContext context) throws ResolvedControlThrowable {
-		invoke(context, (Object) null);
+		invoke(context, (T) null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T arg1, Object arg2) throws ResolvedControlThrowable {
 		invoke(context, arg1);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T arg1, Object arg2, Object arg3) throws ResolvedControlThrowable {
 		invoke(context, arg1);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T arg1, Object arg2, Object arg3, Object arg4) throws ResolvedControlThrowable {
 		invoke(context, arg1);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T arg1, Object arg2, Object arg3, Object arg4, Object arg5) throws ResolvedControlThrowable {
 		invoke(context, arg1);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void invoke(ExecutionContext context, Object[] args) throws ResolvedControlThrowable {
-		Object a = null;
+		T a = null;
 		switch (args.length) {
 			default:             // fall through
-			case 1: a = args[0]; // fall through
+			case 1: a = (T) args[0]; // fall through
 			case 0:
 		}
 		invoke(context, a);

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction2.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction2.java
@@ -16,12 +16,10 @@
 
 package org.classdump.luna.runtime;
 
-import org.classdump.luna.runtime.ResolvedControlThrowable;
-
 /**
  * Abstract function of two arguments.
  */
-public abstract class AbstractFunction2 extends LuaFunction {
+public abstract class AbstractFunction2<T1, T2> extends LuaFunction<T1, T2, Object, Object, Object> {
 
 	@Override
 	public void invoke(ExecutionContext context) throws ResolvedControlThrowable {
@@ -29,32 +27,34 @@ public abstract class AbstractFunction2 extends LuaFunction {
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1) throws ResolvedControlThrowable {
 		invoke(context, arg1, null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2, Object arg3) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2, Object arg3, Object arg4) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2, Object arg3, Object arg4, Object arg5) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void invoke(ExecutionContext context, Object[] args) throws ResolvedControlThrowable {
-		Object a = null, b = null;
+		T1 a = null;
+		T2 b = null;
 		switch (args.length) {
 			default:             // fall through
-			case 2: b = args[1]; // fall through
-			case 1: a = args[0]; // fall through
+			case 2: b = (T2) args[1]; // fall through
+			case 1: a = (T1) args[0]; // fall through
 			case 0:
 		}
 		invoke(context, a, b);

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction3.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction3.java
@@ -16,13 +16,10 @@
 
 package org.classdump.luna.runtime;
 
-import org.classdump.luna.runtime.ExecutionContext;
-import org.classdump.luna.runtime.LuaFunction;
-
 /**
  * Abstract function of three arguments.
  */
-public abstract class AbstractFunction3 extends LuaFunction {
+public abstract class AbstractFunction3<T1, T2, T3> extends LuaFunction<T1, T2, T3, Object, Object> {
 
 	@Override
 	public void invoke(ExecutionContext context) throws ResolvedControlThrowable {
@@ -30,33 +27,36 @@ public abstract class AbstractFunction3 extends LuaFunction {
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1) throws ResolvedControlThrowable {
 		invoke(context, arg1, null, null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2, null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2, T3 arg3, Object arg4) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2, arg3);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2, T3 arg3, Object arg4, Object arg5) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2, arg3);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void invoke(ExecutionContext context, Object[] args) throws ResolvedControlThrowable {
-		Object a = null, b = null, c = null;
+		T1 a = null;
+		T2 b = null;
+		T3 c = null;
 		switch (args.length) {
 			default:             // fall through
-			case 3: c = args[2]; // fall through
-			case 2: b = args[1]; // fall through
-			case 1: a = args[0]; // fall through
+			case 3: c = (T3) args[2]; // fall through
+			case 2: b = (T2) args[1]; // fall through
+			case 1: a = (T1) args[0]; // fall through
 			case 0:
 		}
 		invoke(context, a, b, c);

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction4.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction4.java
@@ -16,12 +16,10 @@
 
 package org.classdump.luna.runtime;
 
-import org.classdump.luna.runtime.ResolvedControlThrowable;
-
 /**
  * Abstract function of four arguments.
  */
-public abstract class AbstractFunction4 extends LuaFunction {
+public abstract class AbstractFunction4<T1, T2, T3, T4> extends LuaFunction<T1, T2, T3, T4, Object> {
 
 	@Override
 	public void invoke(ExecutionContext context) throws ResolvedControlThrowable {
@@ -29,34 +27,38 @@ public abstract class AbstractFunction4 extends LuaFunction {
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1) throws ResolvedControlThrowable {
 		invoke(context, arg1, null, null, null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2, null, null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2, T3 arg3) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2, arg3, null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2, T3 arg3, T4 arg4, Object arg5) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2, arg3, arg4);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void invoke(ExecutionContext context, Object[] args) throws ResolvedControlThrowable {
-		Object a = null, b = null, c = null, d = null;
+		T1 a = null;
+		T2 b = null;
+		T3 c = null;
+		T4 d = null;
 		switch (args.length) {
 			default:             // fall through
-			case 4: d = args[3]; // fall through
-			case 3: c = args[2]; // fall through
-			case 2: b = args[1]; // fall through
-			case 1: a = args[0]; // fall through
+			case 4: d = (T4) args[3]; // fall through
+			case 3: c = (T3) args[2]; // fall through
+			case 2: b = (T2) args[1]; // fall through
+			case 1: a = (T1) args[0]; // fall through
 			case 0:
 		}
 		invoke(context, a, b, c, d);

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction5.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunction5.java
@@ -16,12 +16,10 @@
 
 package org.classdump.luna.runtime;
 
-import org.classdump.luna.runtime.ResolvedControlThrowable;
-
 /**
  * Abstract function of five arguments.
  */
-public abstract class AbstractFunction5 extends LuaFunction {
+public abstract class AbstractFunction5<T1, T2, T3, T4, T5> extends LuaFunction<T1, T2, T3, T4, T5> {
 
 	@Override
 	public void invoke(ExecutionContext context) throws ResolvedControlThrowable {
@@ -29,35 +27,40 @@ public abstract class AbstractFunction5 extends LuaFunction {
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1) throws ResolvedControlThrowable {
 		invoke(context, arg1, null, null, null, null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2, null, null, null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2, T3 arg3) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2, arg3, null, null);
 	}
 
 	@Override
-	public void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4) throws ResolvedControlThrowable {
+	public void invoke(ExecutionContext context, T1 arg1, T2 arg2, T3 arg3, T4 arg4) throws ResolvedControlThrowable {
 		invoke(context, arg1, arg2, arg3, arg4, null);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void invoke(ExecutionContext context, Object[] args) throws ResolvedControlThrowable {
-		Object a = null, b = null, c = null, d = null, e = null;
+		T1 a = null;
+		T2 b = null;
+		T3 c = null;
+		T4 d = null;
+		T5 e = null;
 		switch (args.length) {
 			default:
-			case 5: e = args[4]; // fall through
-			case 4: d = args[3]; // fall through
-			case 3: c = args[2]; // fall through
-			case 2: b = args[1]; // fall through
-			case 1: a = args[0]; // fall through
+			case 5: e = (T5) args[4]; // fall through
+			case 4: d = (T4) args[3]; // fall through
+			case 3: c = (T3) args[2]; // fall through
+			case 2: b = (T2) args[1]; // fall through
+			case 1: a = (T1) args[0]; // fall through
 			case 0:
 		}
 		invoke(context, a, b, c, d, e);

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunctionAnyArg.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractFunctionAnyArg.java
@@ -16,12 +16,10 @@
 
 package org.classdump.luna.runtime;
 
-import org.classdump.luna.runtime.ResolvedControlThrowable;
-
 /**
  * Abstract function of an arbitrary number of arguments.
  */
-public abstract class AbstractFunctionAnyArg extends LuaFunction {
+public abstract class AbstractFunctionAnyArg extends LuaFunction<Object, Object, Object, Object, Object> {
 
 	@Override
 	public void invoke(ExecutionContext context) throws ResolvedControlThrowable {

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction0.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction0.java
@@ -1,0 +1,8 @@
+package org.classdump.luna.runtime;
+
+/**
+ * This class is identical to {@link AbstractFunction0} since this function has no typed arguments at all.
+ */
+@SuppressWarnings("unused")
+public abstract class AbstractUntypedFunction0 extends AbstractFunction0 {
+}

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction0.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction0.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Kay Roepke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.classdump.luna.runtime;
 
 /**

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction1.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction1.java
@@ -1,0 +1,10 @@
+package org.classdump.luna.runtime;
+
+/**
+ * Abstract function of a single argument with an Object type.
+ *
+ * If the argument type is known beforehand, consider using {@link AbstractFunction1}.
+ */
+@SuppressWarnings("unused")
+public abstract class AbstractUntypedFunction1 extends AbstractFunction1<Object> {
+}

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction1.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Kay Roepke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.classdump.luna.runtime;
 
 /**

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction2.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction2.java
@@ -1,0 +1,10 @@
+package org.classdump.luna.runtime;
+
+/**
+ * Abstract function of a two arguments with an Object type.
+ *
+ * If the argument types are known beforehand, consider using {@link AbstractFunction2}.
+ */
+@SuppressWarnings("unused")
+public abstract class AbstractUntypedFunction2 extends AbstractFunction2<Object, Object> {
+}

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction2.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Kay Roepke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.classdump.luna.runtime;
 
 /**

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction3.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction3.java
@@ -1,0 +1,10 @@
+package org.classdump.luna.runtime;
+
+/**
+ * Abstract function of a three arguments with an Object type.
+ *
+ * If the argument types are known beforehand, consider using {@link AbstractFunction3}.
+ */
+@SuppressWarnings("unused")
+public abstract class AbstractUntypedFunction3 extends AbstractFunction3<Object, Object, Object> {
+}

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction3.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction3.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Kay Roepke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.classdump.luna.runtime;
 
 /**

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction4.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction4.java
@@ -1,0 +1,10 @@
+package org.classdump.luna.runtime;
+
+/**
+ * Abstract function of a four arguments with an Object type.
+ *
+ * If the argument types are known beforehand, consider using {@link AbstractFunction4}.
+ */
+@SuppressWarnings("unused")
+public abstract class AbstractUntypedFunction4 extends AbstractFunction4<Object, Object, Object, Object> {
+}

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction4.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction4.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Kay Roepke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.classdump.luna.runtime;
 
 /**

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction5.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction5.java
@@ -1,0 +1,10 @@
+package org.classdump.luna.runtime;
+
+/**
+ * Abstract function of a five arguments with an Object type.
+ *
+ * If the argument types are known beforehand, consider using {@link AbstractFunction5}.
+ */
+@SuppressWarnings("unused")
+public abstract class AbstractUntypedFunction5 extends AbstractFunction5<Object, Object, Object, Object, Object> {
+}

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction5.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/AbstractUntypedFunction5.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Kay Roepke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.classdump.luna.runtime;
 
 /**

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/Dispatch.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/Dispatch.java
@@ -53,42 +53,49 @@ public final class Dispatch {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	static void mt_invoke(ExecutionContext context, Object target) throws ResolvedControlThrowable {
 		LuaFunction fn = callTarget(context, target);
 		if (fn == target) fn.invoke(context);
 		else fn.invoke(context, target);
 	}
 
+	@SuppressWarnings("unchecked")
 	static void mt_invoke(ExecutionContext context, Object target, Object arg1) throws ResolvedControlThrowable {
 		LuaFunction fn = callTarget(context, target);
 		if (fn == target) fn.invoke(context, arg1);
 		else fn.invoke(context, target, arg1);
 	}
 
+	@SuppressWarnings("unchecked")
 	static void mt_invoke(ExecutionContext context, Object target, Object arg1, Object arg2) throws ResolvedControlThrowable {
 		LuaFunction fn = callTarget(context, target);
 		if (fn == target) fn.invoke(context, arg1, arg2);
 		else fn.invoke(context, target, arg1, arg2);
 	}
 
+	@SuppressWarnings("unchecked")
 	static void mt_invoke(ExecutionContext context, Object target, Object arg1, Object arg2, Object arg3) throws ResolvedControlThrowable {
 		LuaFunction fn = callTarget(context, target);
 		if (fn == target) fn.invoke(context, arg1, arg2, arg3);
 		else fn.invoke(context, target, arg1, arg2, arg3);
 	}
 
+	@SuppressWarnings("unchecked")
 	static void mt_invoke(ExecutionContext context, Object target, Object arg1, Object arg2, Object arg3, Object arg4) throws ResolvedControlThrowable {
 		LuaFunction fn = callTarget(context, target);
 		if (fn == target) fn.invoke(context, arg1, arg2, arg3, arg4);
 		else fn.invoke(context, target, arg1, arg2, arg3, arg4);
 	}
 
+	@SuppressWarnings("unchecked")
 	static void mt_invoke(ExecutionContext context, Object target, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5) throws ResolvedControlThrowable {
 		LuaFunction fn = callTarget(context, target);
 		if (fn == target) fn.invoke(context, arg1, arg2, arg3, arg4, arg5);
 		else fn.invoke(context, new Object[] { target, arg1, arg2, arg3, arg4, arg5 });
 	}
 
+	@SuppressWarnings("unchecked")
 	static void mt_invoke(ExecutionContext context, Object target, Object[] args) throws ResolvedControlThrowable {
 		LuaFunction fn = callTarget(context, target);
 		if (fn == target) {
@@ -1383,7 +1390,7 @@ public final class Dispatch {
 	 * @throws IllegalOperationAttemptException  if {@code table} is not a table and does
 	 *                                           not have the {@code __index} metamethod
 	 */
-	@SuppressWarnings("unused")
+	@SuppressWarnings("unchecked")
 	public static void index(ExecutionContext context, Object table, Object key) throws UnresolvedControlThrowable {
 		if (table instanceof Table) {
 			Table t = (Table) table;
@@ -1444,7 +1451,6 @@ public final class Dispatch {
 	 *
 	 * @throws NullPointerException  if {@code context} or {@code table} is {@code null}
 	 */
-	@SuppressWarnings("unused")
 	public static void index(ExecutionContext context, Table table, Object key) throws UnresolvedControlThrowable {
 		// TODO: don't just delegate to the generic case
 		index(context, (Object) Objects.requireNonNull(table), key);
@@ -1493,7 +1499,7 @@ public final class Dispatch {
 	 * @throws IllegalOperationAttemptException  if {@code table} is not a table and does
 	 *                                           not have the {@code __newindex} metamethod
 	 */
-	@SuppressWarnings("unused")
+	@SuppressWarnings("unchecked")
 	public static void setindex(ExecutionContext context, Object table, Object key, Object value) throws UnresolvedControlThrowable {
 		if (table instanceof Table) {
 			Table t = (Table) table;

--- a/luna-runtime/src/main/java/org/classdump/luna/runtime/LuaFunction.java
+++ b/luna-runtime/src/main/java/org/classdump/luna/runtime/LuaFunction.java
@@ -16,12 +16,10 @@
 
 package org.classdump.luna.runtime;
 
-import org.classdump.luna.runtime.ResolvedControlThrowable;
-
 /**
  * An abstract function object.
  */
-public abstract class LuaFunction implements Resumable {
+public abstract class LuaFunction<T1, T2, T3, T4, T5> implements Resumable {
 
 	/**
 	 * Invokes this function in the given execution context {@code context} without arguments.
@@ -66,7 +64,7 @@ public abstract class LuaFunction implements Resumable {
 	 *
 	 * @throws ResolvedControlThrowable  if the call initiates a non-local control change
 	 */
-	public abstract void invoke(ExecutionContext context, Object arg1)
+	public abstract void invoke(ExecutionContext context, T1 arg1)
 			throws ResolvedControlThrowable;
 
 	/**
@@ -91,7 +89,7 @@ public abstract class LuaFunction implements Resumable {
 	 *
 	 * @throws ResolvedControlThrowable  if the call initiates a non-local control change
 	 */
-	public abstract void invoke(ExecutionContext context, Object arg1, Object arg2)
+	public abstract void invoke(ExecutionContext context, T1 arg1, T2 arg2)
 			throws ResolvedControlThrowable;
 
 	/**
@@ -118,7 +116,7 @@ public abstract class LuaFunction implements Resumable {
 	 *
 	 * @throws ResolvedControlThrowable  if the call initiates a non-local control change
 	 */
-	public abstract void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3)
+	public abstract void invoke(ExecutionContext context, T1 arg1, T2 arg2, T3 arg3)
 			throws ResolvedControlThrowable;
 
 	/**
@@ -146,7 +144,7 @@ public abstract class LuaFunction implements Resumable {
 	 *
 	 * @throws ResolvedControlThrowable  if the call initiates a non-local control change
 	 */
-	public abstract void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4)
+	public abstract void invoke(ExecutionContext context, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
 			throws ResolvedControlThrowable;
 
 	/**
@@ -175,7 +173,7 @@ public abstract class LuaFunction implements Resumable {
 	 *
 	 * @throws ResolvedControlThrowable  if the call initiates a non-local control change
 	 */
-	public abstract void invoke(ExecutionContext context, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5)
+	public abstract void invoke(ExecutionContext context, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
 			throws ResolvedControlThrowable;
 
 	/**

--- a/luna-standalone/src/main/java/org/classdump/luna/standalone/Aux.java
+++ b/luna-standalone/src/main/java/org/classdump/luna/standalone/Aux.java
@@ -18,9 +18,9 @@ package org.classdump.luna.standalone;
 
 import org.classdump.luna.impl.NonsuspendableFunctionException;
 import org.classdump.luna.runtime.AbstractFunction0;
-import org.classdump.luna.runtime.AbstractFunction2;
-import org.classdump.luna.runtime.AbstractFunction3;
 import org.classdump.luna.runtime.AbstractFunctionAnyArg;
+import org.classdump.luna.runtime.AbstractUntypedFunction2;
+import org.classdump.luna.runtime.AbstractUntypedFunction3;
 import org.classdump.luna.runtime.Dispatch;
 import org.classdump.luna.runtime.ExecutionContext;
 import org.classdump.luna.runtime.LuaFunction;
@@ -325,7 +325,7 @@ public final class Aux {
 
 	}
 
-	static class Index extends AbstractFunction2 {
+	static class Index extends AbstractUntypedFunction2 {
 
 		static final Index INSTANCE = new Index();
 
@@ -349,7 +349,7 @@ public final class Aux {
 
 	}
 
-	static class SetIndex extends AbstractFunction3 {
+	static class SetIndex extends AbstractUntypedFunction3 {
 
 		static final SetIndex INSTANCE = new SetIndex();
 

--- a/luna-stdlib/src/main/java/org/classdump/luna/lib/ArgumentIterator.java
+++ b/luna-stdlib/src/main/java/org/classdump/luna/lib/ArgumentIterator.java
@@ -648,7 +648,8 @@ public class ArgumentIterator implements Iterator<Object> {
 	 * @throws BadArgumentException  if there is no argument at current position,
 	 *                               or the argument at current position is not a userdata
 	 */
-	public Userdata nextUserdata() {
+	@SuppressWarnings("unchecked")
+	public Userdata<Object> nextUserdata() {
 		return nextUserdata(TYPENAME_USERDATA.toString(), Userdata.class);
 	}
 

--- a/luna-stdlib/src/main/java/org/classdump/luna/lib/DebugLib.java
+++ b/luna-stdlib/src/main/java/org/classdump/luna/lib/DebugLib.java
@@ -888,7 +888,7 @@ public final class DebugLib {
 
 		@Override
 		protected void invoke(ExecutionContext context, ArgumentIterator args) throws ResolvedControlThrowable {
-			Userdata userdata = args.nextUserdata();
+			Userdata<Object> userdata = args.nextUserdata();
 			Object value = args.nextAny();
 
 			userdata.setUserValue(value);

--- a/luna-stdlib/src/main/java/org/classdump/luna/lib/IoFile.java
+++ b/luna-stdlib/src/main/java/org/classdump/luna/lib/IoFile.java
@@ -19,10 +19,6 @@ package org.classdump.luna.lib;
 import org.classdump.luna.ByteString;
 import org.classdump.luna.Table;
 import org.classdump.luna.impl.DefaultUserdata;
-import org.classdump.luna.lib.AbstractLibFunction;
-import org.classdump.luna.lib.ArgumentIterator;
-import org.classdump.luna.lib.BadArgumentException;
-import org.classdump.luna.lib.IoLib;
 import org.classdump.luna.runtime.ExecutionContext;
 import org.classdump.luna.runtime.ResolvedControlThrowable;
 
@@ -31,9 +27,9 @@ import java.io.IOException;
 /**
  * A file handle used by the {@link IoLib I/O library}.
  */
-public abstract class IoFile extends DefaultUserdata {
+public abstract class IoFile<T> extends DefaultUserdata<T> {
 
-	protected IoFile(Table metatable, Object userValue) {
+	protected IoFile(Table metatable, T userValue) {
 		super(metatable, userValue);
 	}
 

--- a/luna-stdlib/src/main/java/org/classdump/luna/lib/IoLib.java
+++ b/luna-stdlib/src/main/java/org/classdump/luna/lib/IoLib.java
@@ -51,7 +51,6 @@ import org.classdump.luna.TableFactory;
 import org.classdump.luna.env.RuntimeEnvironment;
 import org.classdump.luna.impl.UnimplementedFunction;
 import org.classdump.luna.lib.io.InputStreamIoFile;
-import org.classdump.luna.lib.IoFile;
 import org.classdump.luna.lib.io.OutputStreamIoFile;
 import org.classdump.luna.runtime.Dispatch;
 import org.classdump.luna.runtime.ExecutionContext;
@@ -395,9 +394,9 @@ public final class IoLib {
 
 		this.fileSystem = fileSystem;
 
-		stdIn = in != null ? new InputStreamIoFile(in, mt, null) : null;
-		stdOut = out != null ? new OutputStreamIoFile(out, mt, null) : null;
-		stdErr = err != null ? new OutputStreamIoFile(err, mt, null) : null;
+		stdIn = in != null ? new InputStreamIoFile(in, mt) : null;
+		stdOut = out != null ? new OutputStreamIoFile(out, mt) : null;
+		stdErr = err != null ? new OutputStreamIoFile(err, mt) : null;
 
 		defaultInput = stdIn;
 		defaultOutput = stdOut;

--- a/luna-stdlib/src/main/java/org/classdump/luna/lib/io/InputStreamIoFile.java
+++ b/luna-stdlib/src/main/java/org/classdump/luna/lib/io/InputStreamIoFile.java
@@ -24,13 +24,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 
-public class InputStreamIoFile extends IoFile {
+public class InputStreamIoFile extends IoFile<SeekableInputStream> {
 
-	private final SeekableInputStream in;
-
-	public InputStreamIoFile(InputStream in, Table metatable, Object userValue) {
-		super(metatable, userValue);
-		this.in = new SeekableInputStream(Objects.requireNonNull(in));
+	public InputStreamIoFile(InputStream in, Table metatable) {
+		super(metatable, new SeekableInputStream(Objects.requireNonNull(in)));
 	}
 
 	@Override
@@ -58,13 +55,17 @@ public class InputStreamIoFile extends IoFile {
 		switch (whence) {
 			case BEGINNING:
 			case END:
-				return in.setPosition(offset);
+				return inputStream().setPosition(offset);
 
 			case CURRENT_POSITION:
-				return in.addPosition(offset);
+				return inputStream().addPosition(offset);
 
 			default: throw new IllegalArgumentException("Illegal whence: " + whence);
 		}
+	}
+
+	private SeekableInputStream inputStream() {
+		return getUserValue();
 	}
 
 }

--- a/luna-stdlib/src/main/java/org/classdump/luna/lib/io/OutputStreamIoFile.java
+++ b/luna-stdlib/src/main/java/org/classdump/luna/lib/io/OutputStreamIoFile.java
@@ -19,19 +19,15 @@ package org.classdump.luna.lib.io;
 import org.classdump.luna.ByteString;
 import org.classdump.luna.Table;
 import org.classdump.luna.lib.IoFile;
-import org.classdump.luna.lib.io.SeekableOutputStream;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Objects;
 
-public class OutputStreamIoFile extends IoFile {
+public class OutputStreamIoFile extends IoFile<SeekableOutputStream> {
 
-	private final SeekableOutputStream out;
-
-	public OutputStreamIoFile(OutputStream out, Table metatable, Object userValue) {
-		super(metatable, userValue);
-		this.out = new SeekableOutputStream(Objects.requireNonNull(out));
+	public OutputStreamIoFile(OutputStream out, Table metatable) {
+		super(metatable, new SeekableOutputStream(Objects.requireNonNull(out)));
 	}
 
 	@Override
@@ -46,12 +42,12 @@ public class OutputStreamIoFile extends IoFile {
 
 	@Override
 	public void flush() throws IOException {
-		out.flush();
+		outputStream().flush();
 	}
 
 	@Override
 	public void write(ByteString s) throws IOException {
-		s.writeTo(out);
+		s.writeTo(outputStream());
 	}
 
 	@Override
@@ -59,13 +55,17 @@ public class OutputStreamIoFile extends IoFile {
 		switch (whence) {
 			case BEGINNING:
 			case END:
-				return out.setPosition(offset);
+				return outputStream().setPosition(offset);
 
 			case CURRENT_POSITION:
-				return out.addPosition(offset);
+				return outputStream().addPosition(offset);
 
 			default: throw new IllegalArgumentException("Illegal whence: " + whence);
 		}
+	}
+
+	private SeekableOutputStream outputStream() {
+		return getUserValue();
 	}
 
 }

--- a/luna-tests/src/test/java/org/classdump/luna/lib/BasicLibTest.java
+++ b/luna-tests/src/test/java/org/classdump/luna/lib/BasicLibTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class BasicLibTest {
 
-    private static class PairsList extends DefaultUserdata {
+    private static class PairsList extends DefaultUserdata<List<String>> {
         private static final ImmutableTable META_TABLE = new ImmutableTable.Builder()
                 .add(BasicLib.MT_PAIRS, new Pairs())
                 .add(Metatables.MT_INDEX, new Index())
@@ -55,10 +55,6 @@ public class BasicLibTest {
             }});
         }
 
-        private List getList() {
-            return (List) getUserValue();
-        }
-
         private static class Pairs extends AbstractLibFunction {
             @Override
             protected String name() {
@@ -67,7 +63,7 @@ public class BasicLibTest {
 
             @Override
             protected void invoke(ExecutionContext context, ArgumentIterator args) throws ResolvedControlThrowable {
-                final List list = args.nextOfClass(PairsList.class).getList();
+                final List<String> list = args.nextOfClass(PairsList.class).getUserValue();
                 context.getReturnBuffer().setTo(new Next(), list.listIterator(), null);
             }
         }
@@ -80,7 +76,7 @@ public class BasicLibTest {
 
             @Override
             protected void invoke(ExecutionContext context, ArgumentIterator args) throws ResolvedControlThrowable {
-                final List list = args.nextOfClass(PairsList.class).getList();
+                final List<String> list = args.nextOfClass(PairsList.class).getUserValue();
                 final int index = args.nextInt() - 1;
                 if (index == list.size()) {
                     context.getReturnBuffer().setTo(null);

--- a/luna-tests/src/test/scala/org/classdump/luna/compiler/FragmentCompileAndLoadTest.scala
+++ b/luna-tests/src/test/scala/org/classdump/luna/compiler/FragmentCompileAndLoadTest.scala
@@ -82,7 +82,7 @@ class FragmentCompileAndLoadTest extends FunSpec with MustMatchers {
             }
 
             val name = classLoader.install(cm)
-            val clazz = classLoader.loadClass(name).asInstanceOf[Class[LuaFunction]]
+            val clazz = classLoader.loadClass(name).asInstanceOf[Class[LuaFunction[_, _, _, _, _]]]
 
             val f = try {
               clazz.getConstructor(classOf[Variable]).newInstance(new Variable(null))

--- a/luna-tests/src/test/scala/org/classdump/luna/test/BenchmarkRunner.scala
+++ b/luna-tests/src/test/scala/org/classdump/luna/test/BenchmarkRunner.scala
@@ -115,7 +115,7 @@ object BenchmarkRunner {
     env
   }
 
-  case class EnvWithMainChunk(state: StateContext, fn: LuaFunction)
+  case class EnvWithMainChunk(state: StateContext, fn: LuaFunction[_, _, _, _, _])
 
   def init(settings: CompilerSettings, filename: String, args: String*) = {
     val resourceStream = getClass.getResourceAsStream(filename)

--- a/luna-tests/src/test/scala/org/classdump/luna/test/fragments/BasicFragments.scala
+++ b/luna-tests/src/test/scala/org/classdump/luna/test/fragments/BasicFragments.scala
@@ -127,8 +127,8 @@ object BasicFragments extends FragmentBundle with FragmentExpectations with OneL
       |return assert
     """
   }
-  Or1 in EmptyContext succeedsWith (classOf[LuaFunction])
-  Or1 in BasicContext succeedsWith (classOf[LuaFunction])
+  Or1 in EmptyContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
+  Or1 in BasicContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
 
   val Or2 = fragment ("Or2") {
     """local assert = assert or function() return end
@@ -152,8 +152,8 @@ object BasicFragments extends FragmentBundle with FragmentExpectations with OneL
       |return x
     """
   }
-  IfOr1 in EmptyContext succeedsWith (classOf[LuaFunction])
-  IfOr1 in BasicContext succeedsWith (classOf[LuaFunction])
+  IfOr1 in EmptyContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
+  IfOr1 in BasicContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
 
   val IfOr2 = fragment ("IfOr2") {
     """local x
@@ -429,19 +429,19 @@ object BasicFragments extends FragmentBundle with FragmentExpectations with OneL
     """return function() while true do local a = -1 end end
     """
   }
-  InfiniteWhileLoop1 in EmptyContext succeedsWith (classOf[LuaFunction])
+  InfiniteWhileLoop1 in EmptyContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
 
   val InfiniteWhileLoop2 = fragment ("InfiniteWhileLoop2") {
     """return function() while 1 do local a = -1 end end
     """
   }
-  InfiniteWhileLoop2 in EmptyContext succeedsWith (classOf[LuaFunction])
+  InfiniteWhileLoop2 in EmptyContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
 
   val InfiniteWhileLoop3 = fragment ("InfiniteWhileLoop3") {
     """return function () repeat local x = 1 until true end
     """
   }
-  InfiniteWhileLoop3 in EmptyContext succeedsWith (classOf[LuaFunction])
+  InfiniteWhileLoop3 in EmptyContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
 
   val BitwiseOps = fragment ("BitwiseOps") {
     """local x = 3
@@ -655,7 +655,7 @@ object BasicFragments extends FragmentBundle with FragmentExpectations with OneL
       |return x or y
     """
   }
-  Upvalues3 in EmptyContext succeedsWith (classOf[LuaFunction])
+  Upvalues3 in EmptyContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
 
   val Upvalues4 = fragment ("Upvalues4") {
     """local n = 0
@@ -1539,7 +1539,7 @@ object BasicFragments extends FragmentBundle with FragmentExpectations with OneL
       |return ipairs(t)
     """
   }
-  IPairsWithPairsMetatable in BasicContext succeedsWith (classOf[LuaFunction], classOf[Table], 0)
+  IPairsWithPairsMetatable in BasicContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]], classOf[Table], 0)
 
   val IPairsNoTable = fragment ("IPairsNoTable") {
     """ipairs(42)

--- a/luna-tests/src/test/scala/org/classdump/luna/test/fragments/BasicLibFragments.scala
+++ b/luna-tests/src/test/scala/org/classdump/luna/test/fragments/BasicLibFragments.scala
@@ -367,7 +367,7 @@ object BasicLibFragments extends FragmentBundle with FragmentExpectations with O
       program ("return load(42)") succeedsWith (null, classOf[String])
       program ("return load(42, 42, 42)") succeedsWith (null, "attempt to load a text chunk (mode is '42')")
 
-      program ("return load('return nil', nil)") succeedsWith (classOf[LuaFunction])
+      program ("return load('return nil', nil)") succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
 
       program ("return load('return 1 + 2')()") succeedsWith (3)
 

--- a/luna-tests/src/test/scala/org/classdump/luna/test/fragments/CoroutineLibFragments.scala
+++ b/luna-tests/src/test/scala/org/classdump/luna/test/fragments/CoroutineLibFragments.scala
@@ -114,7 +114,7 @@ object CoroutineLibFragments extends FragmentBundle with FragmentExpectations  {
       |return w
     """
   }
-  WrapReturnsAFunction in CoroContext succeedsWith (classOf[LuaFunction])
+  WrapReturnsAFunction in CoroContext succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
 
   val RunningCoroutineStatus = fragment ("RunningCoroutineStatus") {
     """local c = coroutine.running()

--- a/luna-tests/src/test/scala/org/classdump/luna/test/fragments/DebugLibFragments.scala
+++ b/luna-tests/src/test/scala/org/classdump/luna/test/fragments/DebugLibFragments.scala
@@ -72,7 +72,7 @@ object DebugLibFragments extends FragmentBundle with FragmentExpectations with O
           |return nf, vf, ng, vg, vg == f
         """
       }
-      TwoNonENVFunctions in thisContext succeedsWith (null, null, "f", classOf[LuaFunction], true)
+      TwoNonENVFunctions in thisContext succeedsWith (null, null, "f", classOf[LuaFunction[_, _, _, _, _]], true)
 
     }
 
@@ -211,7 +211,7 @@ object DebugLibFragments extends FragmentBundle with FragmentExpectations with O
         """local udata = io.output()
           |local uvalue = debug.getuservalue(debug.setuservalue(io.output(), "hello"))
           |return udata, uvalue
-        """) succeedsWith (classOf[Userdata], "hello")
+        """) succeedsWith (classOf[Userdata[_]], "hello")
 
     }
 

--- a/luna-tests/src/test/scala/org/classdump/luna/test/fragments/IOLibFragments.scala
+++ b/luna-tests/src/test/scala/org/classdump/luna/test/fragments/IOLibFragments.scala
@@ -25,7 +25,7 @@ object IOLibFragments extends FragmentBundle with FragmentExpectations with OneL
 
     about ("io.output") {
 
-      program ("return io.output()") succeedsWith (classOf[Userdata])
+      program ("return io.output()") succeedsWith (classOf[Userdata[Object]])
 
     }
 
@@ -39,7 +39,7 @@ object IOLibFragments extends FragmentBundle with FragmentExpectations with OneL
 
       // TODO: check what is written to the output
 
-      program ("return io.write(1, 2)") succeedsWith (classOf[Userdata])
+      program ("return io.write(1, 2)") succeedsWith (classOf[Userdata[Object]])
       program ("""return io.write({})""") failsWith "bad argument #"<<"1">>" to 'write' (string expected, got table)"
 
     }

--- a/luna-tests/src/test/scala/org/classdump/luna/test/fragments/ModuleLibFragments.scala
+++ b/luna-tests/src/test/scala/org/classdump/luna/test/fragments/ModuleLibFragments.scala
@@ -90,7 +90,7 @@ object ModuleLibFragments extends FragmentBundle with FragmentExpectations with 
 
       program ("return package.searchers") succeedsWith (classOf[Table])
 
-      program ("return package.searchers[1]") succeedsWith (classOf[LuaFunction])
+      program ("return package.searchers[1]") succeedsWith (classOf[LuaFunction[_, _, _, _, _]])
 
     }
 


### PR DESCRIPTION
the rationale is that typically functions receive a well-defined list of argument types
and require either an ArgumentIterator to peel out the values or directly cast their
parameters to the specific type.

Not only is that error prone, it also required duplicate work all over the place.
By allowing to specify the argument types no such casting is required for the common case
as the simple type parameter allows IDEs to properly create method signatures.

The same applies to userdata, which is very often used to expose Java classes into Lua.
In those cases the types are well known to the programmer and no helper fields, type casts or
other checks are required, because the user data is already encapsulated.

Thus the boilerplate required is reduced and the user code becomes clearer.